### PR TITLE
Fix syntax error in C_UnwrapKeyAuthenticated function declaration

### DIFF
--- a/published/3-02/pkcs11f.h
+++ b/published/3-02/pkcs11f.h
@@ -1321,7 +1321,7 @@ CK_PKCS11_FUNCTION_INFO(C_UnwrapKeyAuthenticated)
   CK_ATTRIBUTE_PTR pTemplate,
   CK_ULONG ulAttributeCount,
   CK_BYTE_PTR pAssociatedData,
-  CK_ULONG ulAssociatedDataLen
+  CK_ULONG ulAssociatedDataLen,
   CK_OBJECT_HANDLE_PTR phKey
 );
 #endif


### PR DESCRIPTION
## Description

This PR fixes a syntax error in the `C_UnwrapKeyAuthenticated` function declaration in `pkcs11f.h`. The issue was a missing comma between the `ulAssociatedDataLen` parameter and the `phKey` parameter, which causes compilation failures.

## Changes Made

- Added missing comma after `CK_ULONG ulAssociatedDataLen` parameter in the `C_UnwrapKeyAuthenticated` function declaration

## Error Details

The missing comma caused the following compilation error:
error: expected ',' or '...' before 'CK_OBJECT_HANDLE_PTR'
1325 |   CK_OBJECT_HANDLE_PTR phKey
|   ^~~~~~~~~~~~~~~~~~~~


## Testing

- Verified that the fix resolves the compilation error
- Tested with GCC 12.2.0 on Linux x86_64 (Debian)
- No functional changes, only syntax correction

## References

- OASIS PKCS #11 Specification: https://docs.oasis-open.org/pkcs11/pkcs11-spec/v3.2/pkcs11-spec-v3.2.html
- Related function: C_UnwrapKeyAuthenticated (PKCS #11 v3.2)

---

This is a minor but critical fix that ensures the header files compile correctly across different compilers and platforms.