### PR TITLE
PKCS#11 issue 19 latest ExternaMu generation proposal.

### DIFF
--- a/working/doc/spec/ml_dsa.md
+++ b/working/doc/spec/ml_dsa.md
@@ -369,7 +369,7 @@ keys in bytes.
 
 The ExternalMu-ML-DSA generation mechanism, denoted **CKM_ML_DSA_EXTERNAL_MU_GEN**, is a mechanism for the calculation of the ExternalMu that can be consumed by the CKM_ML_DSA_EXTERNAL_MU mechanism only single-part signature and verification for ML-DSA signatures, as defined in sections 5 and 6 of [FIPS-204].  CKM_ML_DSA_EXTERNAL_MU_GEN  mechanism can be used for single-part and multiple-part digest operations.
 
-CKM_ML_DSA_EXTERNAL_MU_GEN  will take a mechanism params  **CK_MU_GEN_PARAMS** the params supplies a key handle or a precomputed TR of the public key. If the key handles is empty then then a TR is expected. An additional context can also be supplied. Constraints on the length of the data are summarized in the following table.
+CKM_ML_DSA_EXTERNAL_MU_GEN  will take a mechanism params  **CK_MU_GEN_PARAMS**. The params supplies a key handle or a precomputed TR of the public key. If the key handle is empty then then a TR is expected. An additional context can also be supplied. Constraints on the length of the data are summarized in the following table.
 
 | Function          | Input Length | Output Length |
 |-------------------|--------------|---------------|


### PR DESCRIPTION
Create a mechanisum for the creation/compute Mu by a module/provider to possibly be consued byt a second provider user the C_Digest or C_DigestUpdate functions to return a 64 byte Mu to be consumed as the package/test in single part C_Sign()

As per https://csrc.nist.gov/csrc/media/Projects/post-quantum-cryptography/documents/faq/fips204-sec6-03192025.pdf

See excert::

<img width="640" height="812" alt="image" src="https://github.com/user-attachments/assets/4b431bfc-018f-4a57-914d-d26d66d4aaa2" />
