### PR TITLE
Add parameter set attributes to mechanism spec

### DIFF
--- a/working/doc/spec/mechanism_objects.md
+++ b/working/doc/spec/mechanism_objects.md
@@ -13,6 +13,32 @@ beyond that given by the **CK_MECHANISM_INFO** structure.
 | Attribute          | Data Type         | Meaning                        |
 |--------------------|-------------------|--------------------------------|
 | CKA_MECHANISM_TYPE | CK_MECHANISM_TYPE | The type of mechanism object   |
+| CKA_SUPPORTED_PARAMETER_SETS | CK_ULONG_PTR | Array of parameter sets supported by the mechanism. The number of entries in the array is the ulValueLen component of the attribute divided by the size of CK_ULONG |
+| CKA_FLAGS | CK_FLAGS | Bit flags specifying mechanism capabilities      |
 table: Common Mechanism Attributes
 
-The **CKA_MECHANISM_TYPE** attribute may not be set.
+The **CKO_MECHANISM** object allows applications to probe information about what
+parameter sets are supported by specific mechanisms. This is used to signal to
+applications partial implementations of mechanisms where not all the parameter
+sets are supported (perhaps because new parameters were added in a later
+specification).
+
+For example, if a token supports only fast parameter sets for the
+**CKM_SLH_DSA** mechanism, the **CKO_MECHANISM** object representing this
+mechanism will contain a **CKA_SUPPORTED_PARAMETER_SETS** array with only
+parameters like **CKP_SLH_DSA_SHA2_128F** but none of the small ones like
+**CKP_SLH_DSA_SHA2_128S**.
+
+Note: applications SHOULD verify the parameter set they want to use is supported
+by the specific mechanism they intend to use and not make assumptions based on
+the presence of objects on the token or related mechanisms.  For example related
+mechanism (like CKM_ML_KEM and CKM_ML_KEM_KEY_PAIR_GEN) may not necessarily
+support the same set of parameters if a token can import and use but not
+generate keys with certain parameters, possibly because a security certification
+allow to use old keys for verification operations but do not allow generating
+new keys with parameter sets considered weak.
+
+The **CKA_MECHANISM_TYPE** is required to allow applications to find information
+about a specific mechanism.
+
+**CKO_MECHANISM** objects are unmodifiable by applications.


### PR DESCRIPTION
Update the mechanism objects documentation to include CKA_SUPPORTED_PARAMETER_SETS and CKA_FLAGS. This enables applications to probe for partial mechanism implementations and verify specific parameter support, such as for SLH-DSA variants, before attempting operations.

Fixes: #67 