### PR TITLE
Update KMAC heading to level 2

### DIFF
--- a/working/doc/spec/kmac.md
+++ b/working/doc/spec/kmac.md
@@ -1,4 +1,4 @@
-# KMAC
+## KMAC
 
 KMAC is a family of message authentication codes based on KECCAK, as defined
 in [NIST SP800-185].


### PR DESCRIPTION
Change the KMAC title from a level 1 to a level 2 heading. This adjusts the document structure to ensure it nests correctly within the broader documentation hierarchy.