### PR TITLE
Outdated key sizes for operation in fips mode

### DIFF
--- a/working/doc/spec/dsa.md
+++ b/working/doc/spec/dsa.md
@@ -68,7 +68,7 @@ Mechanisms:
 \  
 
 CK_DSA_PARAMETER_GEN_PARAM is a structure which provides and returns parameters
-for the [NIST FIPS 186-4] parameter generating algorithms.
+for the [FIPS PUB 186-4] parameter generating algorithms.
 
 CK_DSA_PARAMETER_GEN_PARAM_PTR is a pointer to a CK_DSA_PARAMETER_GEN_PARAM.
 
@@ -269,7 +269,7 @@ CK_ATTRIBUTE template[] = {
 
 The DSA key pair generation mechanism, denoted **CKM_DSA_KEY_PAIR_GEN**, is a
 key pair generation mechanism based on the Digital Signature Algorithm defined
-in FIPS PUB 186-2.
+in [FIPS PUB 186-4].
 
 This mechanism does not have a parameter.
 
@@ -293,7 +293,7 @@ in bits.
 
 The DSA domain parameter generation mechanism, denoted
 **CKM_DSA_PARAMETER_GEN**, is a domain parameter generation mechanism based on
-the Digital Signature Algorithm defined in FIPS PUB 186-2.
+the Digital Signature Algorithm defined in [FIPS PUB 186-4].
 
 This mechanism does not have a parameter.
 
@@ -385,7 +385,7 @@ in bits.
 
 The DSA without hashing mechanism, denoted **CKM_DSA**, is a mechanism for
 single-part signatures and verification based on the Digital Signature Algorithm
-defined in FIPS PUB 186-2. (This mechanism corresponds only to the part of DSA
+defined in [FIPS PUB 186-4]. (This mechanism corresponds only to the part of DSA
 that processes the 20-byte hash value; it does not compute the hash value.)
 
 For the purposes of this mechanism, a DSA signature is a 40-byte string,
@@ -451,14 +451,4 @@ table: DSA with SHA-1: Key And Data Length
 For this mechanism, the _ulMinKeySize_ and _ulMaxKeySize_ fields of the
 **CK_MECHANISM_INFO** structure specify the supported range of DSA prime sizes,
 in bits.
-
-### FIPS 186-4
-
-When **CKM_DSA** is operated in FIPS mode, only the following bit lengths of p
-and q, represented by L and N, SHALL be used:
-
-L = 1024, N = 160  
-L = 2048, N = 224  
-L = 2048, N = 256  
-L = 3072, N = 256  
 

--- a/working/doc/spec/elliptic_curves.md
+++ b/working/doc/spec/elliptic_curves.md
@@ -1574,14 +1574,3 @@ _pSharedData_
 
 CK_ECDH_AES_KEY_WRAP_PARAMS_PTR is a pointer to a CK_ECDH_AES_KEY_WRAP_PARAMS.
 
-### FIPS 186-4
-
-When **CKM_ECDSA** is operated in FIPS mode, the curves SHALL either be NIST
-recommended curves (with a fixed set of domain parameters) or curves with domain
-parameters generated as specified by [ANSI X9.62]. The NIST recommended curves
-are:
-
-P-192, P-224, P-256, P-384, P-521  
-K-163, B-163, K-233, B-233  
-K-283, B-283, K-409, B-409  
-K-571, B-571  

--- a/working/doc/spec/rsa.md
+++ b/working/doc/spec/rsa.md
@@ -1055,7 +1055,3 @@ _pOAEPParams_
 **CK_RSA_AES_KEY_WRAP_PARAMS_PTR** is a pointer to a
 **CK_RSA_AES_KEY_WRAP_PARAMS**.
 
-### FIPS 186-4
-
-When *CKM_RSA_PKCS* is operated in FIPS mode, the length of the modulus SHALL
-only be 1024, 2048, or 3072 bits.

--- a/working/doc/spec/slot_and_token_mgmt_functions.md
+++ b/working/doc/spec/slot_and_token_mgmt_functions.md
@@ -317,7 +317,7 @@ supported by a token. _slotID_ is the ID of the token’s slot; type is the type
 of mechanism; pInfo points to the location that receives the mechanism
 information.
 
-Note: A cryptographic module may support different mechanisms and minimum and maximum key sizes, parameter sets, modes of operation and other capabilities for supported mechanisms, when operated in a mode compliant to FIPS 140 or some other certification or approval scheme than when operated in non-compliance mode. If the module does change its capabilities in when switching from non-compliance mode to compliance mode and vice versa, this ought to be reflected in its reported mechanisms, key sizes, etc. See the user guidance and security policy of a specific token for restrictions when operated in compliance mode.
+Note: A cryptographic module may support different mechanisms and minimum and maximum key sizes, parameter sets, modes of operation and other capabilities for supported mechanisms, when operated in a mode compliant to FIPS 140 or some other certification or approval scheme than when operated in non-compliance mode. If the module does change its capabilities when switching from non-compliance mode to compliance mode and vice versa, this ought to be reflected in its reported mechanisms, key sizes, etc. See the user guidance and security policy of a specific token for restrictions when operated in compliance mode.
 
 Return values: CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
 CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR,

--- a/working/doc/spec/slot_and_token_mgmt_functions.md
+++ b/working/doc/spec/slot_and_token_mgmt_functions.md
@@ -317,6 +317,8 @@ supported by a token. _slotID_ is the ID of the token’s slot; type is the type
 of mechanism; pInfo points to the location that receives the mechanism
 information.
 
+Note: A cryptographic module may support different mechanisms and minimum and maximum key sizes, parameter sets, modes of operation and other capabilities for supported mechanisms, when operated in a mode compliant to FIPS 140 or some other certification or approval scheme than when operated in non-compliance mode. If the module does change its capabilities in when switching from non-compliance mode to compliance mode and vice versa, this ought to be reflected in its reported mechanisms, key sizes, etc. See the user guidance and security policy of a specific token for restrictions when operated in compliance mode.
+
 Return values: CKR_CRYPTOKI_NOT_INITIALIZED, CKR_DEVICE_ERROR,
 CKR_DEVICE_MEMORY, CKR_DEVICE_REMOVED, CKR_FUNCTION_FAILED, CKR_GENERAL_ERROR,
 CKR_HOST_MEMORY, CKR_MECHANISM_INVALID, CKR_OK, CKR_SLOT_ID_INVALID,


### PR DESCRIPTION
Remove outdated sections "FIPS 186-4" for RSA/DSA/ECDSA operation in FIPS mode, and fix references to FIPS 186-2/-4.

This fixes issue #80 .