### PR TITLE
Add output convention to C_EncapsulateKey

### DIFF
--- a/working/doc/spec/key_management_functions.md
+++ b/working/doc/spec/key_management_functions.md
@@ -756,6 +756,9 @@ The new key will have:
 If a call to **C_EncapsulateKey** cannot support the precise template supplied
 to it, it will fail and return without creating any key object.
 
+**C_EncapsulateKey** uses the convention described in Section 5.2 on producing
+output.
+
 To partition the encapsulation keys so they can only encapsulate a subset of
 keys the attribute **CKA_ENCAPSULATE_TEMPLATE** can be used on the encapsulation
 keys to specify an attribute set that will be compared against the attributes of


### PR DESCRIPTION
Update the documentation for the C_EncapsulateKey function to explicitly state that it follows the standard output conventions described in Section 5.2. This provides clearer guidance for implementers on how the function produces output and ensures consistency within the specification.

Fixes #15 