### PR TITLE
Add missing texlive packages to docs build workflow

### DIFF
--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -9,6 +9,7 @@ on:
   pull_request:
     branches: ["master"]
     paths:
+      - '.github/workflows/**'
       - 'working/doc/spec/**'
 
 jobs:

--- a/.github/workflows/build-docs.yml
+++ b/.github/workflows/build-docs.yml
@@ -27,6 +27,11 @@ jobs:
                   dejavu-sans-fonts \
                   dejavu-sans-mono-fonts \
                   dejavu-serif-fonts \
+                  texlive-amsfonts \
+                  texlive-bookmark \
+                  texlive-booktabs \
+                  texlive-enumitem \
+                  texlive-fancyvrb \
                   texlive-fontspec \
                   texlive-framed \
                   texlive-geometry \


### PR DESCRIPTION
Installs all required texlive- subpackages one by one.
Unfortunately we can't just install texlive-* because that's 5500+ subpackages...