### PR TITLE
Document 32-bit limit for CK_ULONG values

### DIFF
--- a/working/doc/spec/introduction.md
+++ b/working/doc/spec/introduction.md
@@ -300,6 +300,8 @@ sometimes perhaps 64 bits). However, these details should not affect an
 application, assuming it is compiled with Cryptoki header files consistent
 with the Cryptoki library to which the application is linked.
 
+Note that CK_ULONG, regardless of the underlying implementation-defined size, can only ever contain values up to the maximum value representable as a 32-bit signed integer. This is needed to assure compatibility with all supported platforms and platform drivers. Any type defined in terms of CK_ULONG carries the same restriction.
+
 All numbers and values expressed in this document are decimal, unless they are
 preceded by “0x”, in which case they are hexadecimal values.
 


### PR DESCRIPTION
Update the introduction specification to clarify that CK_ULONG and its derived types are restricted to the maximum value of a 32-bit signed integer, regardless of the underlying implementation size. This explicitly documents the limitation required to ensure compatibility across all supported platforms and platform drivers.

Fixes #111