### PR TITLE
Address issues in ticket #100

### DIFF
--- a/working/doc/spec/comp_sig.md
+++ b/working/doc/spec/comp_sig.md
@@ -1,7 +1,7 @@
 ## Composite Signature
 
 Composite Signatures are mechanisms for signatures and verification, following
-the digital signature algorithm defined in [COMP_SIG]
+the digital signature algorithm defined in [COMP_SIG].
 
 +--------------------------------------+---------------------------------------------------+
 |                                      | Functions                                         |
@@ -161,7 +161,7 @@ CK_ATTRIBUTE template[] = {
 
 The Composite Signature key pair generation mechanism, denoted
 **CKM_COMP_SIG_KEY_PAIR_GEN**, is a key pair generation mechanism using
-KeyGen() as defined in section 4.1 of [COMP_SIG]
+KeyGen() as defined in section 3.1 of [COMP_SIG]
 
 It takes **CK_COMP_SIG_PARAMETER_SET_TYPE** to denote the composite component
 algorithms, the composite label and the hash function. 
@@ -183,16 +183,16 @@ For this mechanism, the ulMinKeySize and ulMaxKeySize fields of the
 Signature public key in bytes.
 
 
-### Composite Signature Mechanism
+### Composite Signature
 
 The composite signature mechanism, denoted **CKM_COMP_SIG**, is a mechanism for
-generating and verifying Composite Signatures as defined in sections 4.2 and 4.3
-of [COMP_SIG], Algorithm 4.2 Sign and Algorithm 4.3 Verify, using SHA256, SHA512
-or SHAKE256 as the hash function. The data passed in is the message M.
+generating and verifying Composite Signatures as defined in sections 3.2 and 3.3
+of [COMP_SIG] using SHA256, SHA512 or SHAKE256 as the hash function. The data
+passed in is the message M.
 
 The composite signature mechanism, denoted **CKM_COMP_SIG_EXTERNAL_HASH**, is a
 mechanism for generating and verifying Composite Signatures as defined in
-sections 4.2 and 4.3 of [COMP_SIG] using SHA256, SHA512 or SHAKE256 as the hash
+sections 3.2 and 3.3 of [COMP_SIG] using SHA256, SHA512 or SHAKE256 as the hash
 function. The data passed in is the pre-hash of the message PH(M).  The hash
 algorithm used is the hash algorithm specified in the
 **CK_COMP_SIG_PARAMETER_SET_TYPE** for the specific composite.  For example, a
@@ -213,7 +213,7 @@ bytes of the Composite Signature.
 | C_VerifySignature | Composite Signature Public Key  | any, k       | N/A           |
 table: Composite Signature: Key and Data Length
 
-^1^ Single-part operations only.
+^1^ Single-part operations only when the CKM_COMP_SIG_EXTERNAL_HASH mechanism is used.
 
 For these mechanisms, the _ulMinKeySize_ and _ulMaxKeySize_ fields of the
 **CK_MECHANISM_INFO** structure specify the supported range of Composite


### PR DESCRIPTION
Address the editorial issues from #100.    At this time the IETF specification is in the final publishing queue waiting publication, so there shouldn't be any more section changes.  The only thing that will eventually have to change is the reference in spec_files.txt once it becomes an RFC.