### PR TITLE
Doc cleanup

### DIFF
--- a/working/doc/spec/double_ratchet.md
+++ b/working/doc/spec/double_ratchet.md
@@ -136,7 +136,7 @@ _kdfMechanism_
 CKM_X2RATCHET_RESPOND mechanism. It is defined as follows:
 
 ~~~{.c}
-Typedef struct CK_X2RATCHET_RESPOND_PARAMS {
+typedef struct CK_X2RATCHET_RESPOND_PARAMS {
 	CK_BYTE_PTR	sk;
 	CK_OBJECT_HANDLE	own_prekey;
 	CK_OBJECT_HANDLE	initiator_identity;

--- a/working/doc/spec/function_return_values.md
+++ b/working/doc/spec/function_return_values.md
@@ -422,7 +422,7 @@ may return any applicable error code.
   **C_GenerateRandom**. It indicates that the token’s random number generator
   has not yet been seeded, or requires re-seeding, by **C_SeedRandom**.
 
-* CKR_SESSION_ASYN**C_NOT**_SUPPORTED: This value is returned if the token
+* CKR_SESSION_ASYNC_NOT_SUPPORTED: This value is returned if the token
   doesn’t support async operations.
 
 * CKR_SESSION_COUNT: This value can only be returned by **C_OpenSession**. It

--- a/working/doc/spec/gost_28147-89.md
+++ b/working/doc/spec/gost_28147-89.md
@@ -83,7 +83,7 @@ attributes, in addition to the common attributes defined for this object class:
 
 | Attribute         | Data Type  | Meaning                                   |
 |-------------------|------------|-------------------------------------------|
-| CKA_VALUE1        | Byte array | DER-encoding of the domain parameters as it was introduced in [4] section 8.1 (type Gost28147-89-ParamSetParameters) |
+| CKA_VALUE ^1^     | Byte array | DER-encoding of the domain parameters as it was introduced in [4] section 8.1 (type Gost28147-89-ParamSetParameters) |
 | CKA_OBJECT_ID ^1^ | Byte array | DER-encoding of the object identifier indicating the domain parameters  |
 table: GOST 28147-89 Domain Parameter Object Attributes
 

--- a/working/doc/spec/slh-dsa.md
+++ b/working/doc/spec/slh-dsa.md
@@ -84,7 +84,7 @@ Parameter set types:
 - CKP_SLH_DSA_SHA2_256S
 - CKP_SLH_DSA_SHAKE_256S
 - CKP_SLH_DSA_SHA2_256F
-- CKP_SLH_DSA_SHAKE_256S
+- CKP_SLH_DSA_SHAKE_256F
             
 ### SLH-DSA public key objects
 


### PR DESCRIPTION
Fixes:
 doc/spec/gost_28147-89.md: CKA_VALUE1 -> CKA_VALUE ^1^  (footnote didn't have correct formating creating a new identifier CKA_VALUE1)
doc/spec/slh-dsa.md: CKP_SLH_DSA_SHAKE_256S -> CKP_SLH_DSA_SHAKE_256F (CKP_SLH_DSA_SHAKE_256S is defined twice causing CKP_SLH_DSA_SHAKE_256F to be missing from the spec.
doc/spec/function_return_values.md: CKR_SESSION_ASYN**C_NOT**_SUPPORTED: -> CKR_SESSION_ASYNC_NOT_SUPPORTED: The invalid formatting causes the scanner to find CKR_SESSiON_ASYN as the error (which would be missing from the header), and to find CKR_SESSION_ASYNC_NOT_SUPPORTED to be used in the spec without being defined in function_return_values.md.

identifier issues that are not fixed by this patch but still need to be:

1. The following return codes were used in function retun blocks, but
 not define in 'function_return_values.md' return code section:
    CKR_AEAD_DECRYPT_FAILED define in ../doc/spec/message_based_decryption_functions.md:102,../doc/spec/message_based_decryption_functions.md:211
    CKR_TOKEN_RESOURCE_EXCEEDED define in ../doc/spec/signing_and_macing_functions.md:81, (many more)

2. The following return codes were used in the spec but defined in neither
 function return blocks nor in 'function_return_values.md':
    CKR_NEW_PIN_MODE defined in ../doc/spec/otp_mechanisms.md line 295
    CKR_NEXT_OTP defined in ../doc/spec/otp_mechanisms.md line 298
    CKR_KEY_EXHAUSTED defined in ../doc/spec/hss.md line 175

3. The following is defined in the header, but in neither spec nor historical:
   #define CKM_TLS10_MAC_CLIENT                      0x000003d7UL missing from doc 'spec' (may not be and error)
    #define CKM_TLS10_MAC_SERVER                     0x000003d6UL missing from doc 'spec' (may not be and error)
    #define CKM_TLS_KEY_AND_MAC_DERIVE        0x00000376UL missing from doc 'spec' (may not be and error)
    #define CKM_TLS_MASTER_KEY_DERIVE            0x00000375UL missing from doc 'spec' (may not be and error)
    #define CKM_TLS_MASTER_KEY_DERIVE_DH     0x00000377UL missing from doc 'spec' (may not be and error)
    #define CKM_TLS_PRF                                         0x00000378UL missing from doc 'spec' (may not be and error)

(did we removed the pre-tls 1.2 defines we still have ssl3 defines in the document. we should probably be consistent and move ssl3 to historial and add the pre-tls 1.2 defines to historical)
