### PR TITLE
Update parse_doc to work with .md files

### DIFF
--- a/working/identifier_db/parse_doc.pl
+++ b/working/identifier_db/parse_doc.pl
@@ -18,15 +18,30 @@ glob $print_diff_typedefs=0;
 glob $print_diff_struct=0;
 glob $verbose=0;
 glob $verbose2=0;
+glob $silence_doc_errors=0;
+glob $has_historical=0;
+glob $has_profile=0;
+glob $is_skipping=0;
+glob $next_deprecated=0;
+glob $next_historical=0;
+glob $next_profile=0;
 
 glob $table_number=0;
+glob $table_total_count=0;
+glob $table_index="";
 glob $current_row_count=0;
 glob $current_column_count=0;
-glob $inTable=0;
-glob $inMultiline=0;
-glob $inStruct=0;
-glob $expectStruct=0;
-glob $tableHeaderNotStarted=0;
+glob $row_found=0;
+glob $return_value_count=0;
+glob $naked_return_count=0;
+glob $line_continue=0;
+glob $in_table=0;
+glob $in_table_2=0;
+glob $in_return_value=0;
+glob $in_multiline=0;
+glob $in_struct=0;
+glob $expect_struct=0;
+glob $in_table_header=0;
 glob $typedef_count=0;
 glob $header_typedef_count=0;
 glob %typedef_struct_name = ();
@@ -35,20 +50,38 @@ glob %typedef_present=();
 glob %struct_value = ();
 glob %table_entry = ();
 glob %table_col_count = ();
+glob %table_name = ();
+glob %table_doc = ();
+glob %table_row_count = ();
 glob %header_typedef_struct_name = ();
 glob %header_typedef_struct_count = ();
 glob %header_struct_value = ();
 glob %header_typedef_present = ();
-glob @table_name = ();
-glob @table_count = ();
-glob @table_index = ();
+glob @table_indices = ();
 glob @typedef_names = ();
+glob @naked_return_values = ();
+glob @naked_return_doc = ();
+glob @naked_return_line = ();
+glob @return_doc = ();
+glob @return_values = ();
+glob @return_doc = ();
+glob @return_line = ();
 glob @header_typedef_names = ();
 glob $idspec="[a-zA-Z]\\w*";
+glob $number="\\d+";
+# future read these two from a file
+# special identifiers not match the normal matching rules, but are expected to be defined in the document
+# note CKR_VENDOR_DEFINED is handled separately so we can detect improper use in the function Return value lists.
+glob @special_identifiers = ( "CK_FALSE", "CK_TRUE", "CK_INVALID_HANDLE", "CK_EFFECTIVELY_INFINITE", "CK_UNAVAILABLE_INFORMATION", "CKA_VENDOR_DEFINED", "CKM_VENDOR_DEFINED", "TRUE", "FALSE" );
+# header specific are defines that are part of the header machinery and not meantioned in the document
+glob @header_specific = ( "CRYPTOKI_VERSION_AMENDMENT", "CRYPTOKI_VERSION_MAJOR", "CRYPTOKI_VERSION_MINOR", "_PKCS11T_H_" );
+#
 
 glob $doc_file="";
+glob $doc_dir="";
 glob $header_file="";
 glob $Command="./parse_doc.pl";  # get from the evironment?
+glob $BASE="..";
 
 foreach (@ARGV) {
     $arg=$_;
@@ -64,54 +97,54 @@ foreach (@ARGV) {
         $print_doc_defines=1;
         $print_header_defines=1;
         next;
-    } 
+    }
     if ($arg eq "structs") {
         $print_doc_structs=1;
         $print_header_structs=1;
         next;
-    } 
+    }
     if ($arg eq "typedefs") {
         $print_doc_typedefs=1;
         $print_header_typedefs=1;
         next;
-    } 
+    }
     if ($arg eq "doc_defines") {
         $print_doc_defines=1;
         next;
-    } 
+    }
     if ($arg eq "doc_structs") {
         $print_doc_structs=1;
         next;
-    } 
+    }
     if ($arg eq "doc_typedefs") {
         $print_doc_typedefs=1;
         next;
-    } 
+    }
     if ($arg eq "header_defines") {
         $print_header_defines=1;
         next;
-    } 
+    }
     if ($arg eq "header_structs") {
         $print_header_structs=1;
         next;
-    } 
+    }
     if ($arg eq "header_typedefs") {
         $print_header_typedefs=1;
         next;
-    } 
+    }
     if ($arg eq "diff_defines") {
         $print_diff_defines=1;
         printf("diff_defines, setting print_diff_defines=$print_diff_defines\n");
         next;
-    } 
+    }
     if ($arg eq "diff_structs") {
         $print_diff_structs=1;
         next;
-    } 
+    }
     if ($arg eq "diff_typedefs") {
         $print_diff_typedefs=1;
         next;
-    } 
+    }
     if ($arg eq "doc_all") {
         $print_doc_tables=1;
         $print_doc_defines=1;
@@ -153,17 +186,22 @@ foreach (@ARGV) {
         $verbose2=1;
         next;
     }
-    if ($doc_file eq "")  {
-        $doc_file=$arg;
+    if ($arg eq "no_doc_erros") {
+        $silence_doc_errors=1;
         next;
+    }
+    if ($arg =~ /^base=(.*)$/) {
+       $BASE=$base;
     }
     if ($header_file eq "") {
         $header_file=$arg;
         next;
     }
-    printf "-- unknown command %s doc_file=%s header_file=%s\n", $arg, $doc_file, $header_file;
-    usage();
-    exit;
+    if ($doc_file eq "") {
+        $doc_file=$arg;
+        next;
+    }
+    $doc_file="$doc_file $arg";
 }
 
 # default to diff_all
@@ -204,30 +242,16 @@ if (($print_header_defines == 1) ||
 }
 
 
-if ($need_doc==0 && $need_header==1 &&  $header_file eq "") {
-    $header_file=$doc_file;
-    $doc_file="";
+if ($need_doc==1 && $need_header==0 && $header_file ne "") {
+    $doc_file="$header_file $doc_file"
 }
 
 if ($need_doc==1 && $doc_file eq "") {
-    foreach $file (<./pkcs11-spec-v*.txt>) {
-        if ($doc_file eq "") {
-            $doc_file=$file;
-        } else {
-            if ($doc_file lt $file) {
-                $doc_file=$file;
-            }
-        }
-    }
-    if ($doc_file eq "") {
-        print "No pkcs11-spec-v*.txt file found, and no doc file supplied on command line\n";
-        usage();
-        exit;
-    }
+    $doc_file="spec";
 }
 
 if ($need_header==1 &&  $header_file eq "") {
-    $header_file="../headers/pkcs11t.h";
+    $header_file="${BASE}/headers/pkcs11t.h";
 }
 
 if ($need_header==1) {
@@ -239,8 +263,19 @@ if ($need_header==1) {
     $function_header_file=File::Spec->catfile(@dirs, "pkcs11.h");
 }
 
+$test=$doc_file;
+if ( $test =~ /hist/ ) {
+    $has_historical=1;
+}
+$test=$doc_file;
+if ( $test =~ /profiles/ ) {
+    $has_profile=1;
+}
+
 if ($verbose == 1) {
-    print  "doc_file=$doc_file header_file=$header_file function_header_file=$function_header_file\n";
+    print "doc_file=$doc_file header_file=$header_file function_header_file=$function_header_file\n";
+    print " \$has_historical=$has_historical\n";
+    print " \$has_profile=$has_profile\n";
     print " \$print_doc_defines=$print_doc_defines\n";
     print " \$print_doc_structs=$print_doc_structs\n";
     print " \$print_doc_typedefs=$print_doc_typedefs\n";
@@ -255,8 +290,54 @@ if ($verbose == 1) {
 
 # read the interesting stuff out of the text document
 my $line=0;
+my $short_doc="";
 if ($doc_file ne "") {
-    open(my $doc, "<", $doc_file) or die "Can't open $doc_file: $!";
+  @tx=split(' ', $doc_file);
+  foreach (@tx) {
+   $doc_dir=$_;
+   # verify the list exists
+   $current_dir="$BASE/doc/$doc_dir";
+   $listfile="$current_dir/files.txt";
+   # sigh files file in the spec directory is named differently
+   if ($doc_dir eq "spec") {
+       $listfile="$current_dir/spec_files.txt";
+   }
+   if ($verbose == 1) {
+       print "--- parsing directory=\"$doc_dir\" using $listfile\n";
+   }
+   $table_number=0; # reset set the table counter for every separate spec
+   open(my $doc_list, "<", "$listfile") or die "Can't open $listfile: $!";
+   while (<$doc_list>) {
+    $line=0;
+    if ($in_table == 1 || $in_table_2 == 1) {
+        # we can use lc here because the two files we are comparing against have no unicode characters
+        # so if lc chokes on unicode in $short_doc, it's fine because it shouldn't match in that case anyway
+        $short_case= lc($short_doc);
+        if (($short_case ne "acknowledgements.md") && ($short_case ne "revsion_history.md")) {
+            printf(" ERROR uncompleted table in $current_doc!\n");
+        }
+        $in_table=0;
+        $in_table_2=0;
+        $table_name{$table_index}="unknown".$table_index;
+        $table_row_count{$table_index}=$current_row_count;
+    }
+    if ($in_struct == 1) {
+        printf(" ERROR uncompleted struct in $current_doc!\n");
+        $in_struct=0;
+    }
+    if ($in_return_value == 1) {
+        # this is not an error, several files have the Return Value: block as the
+        # last thing in the file, so just close it out here.
+        #printf(" ERROR uncompleted Return Value: block in $current_doc!\n");
+        $in_return_value=0;
+    }
+    chomp;
+    $short_doc=$_;
+    $current_doc="$current_dir/$short_doc";
+    if ($verbose == 1) {
+        print "     parsing file=\"$short_doc\" ($current_doc)\n";
+    }
+    open(my $doc, "<", "$current_doc") or die "Can't open $current_doc: $!";
     while (<$doc>){
         $entry=$_;
         chomp $entry;
@@ -268,41 +349,59 @@ if ($doc_file ne "") {
         $entry=~s/&nbsp;/ /g;
         $entry=~s/&amp;/&/g;
         $line++;
-        if ($expectStruct == 1) {
-            $expectStruct=0;
+        $test=lc($entry);
+        if ( $test =~ /deprecated/ ) {
+            # if we have a deprecated statement on the line,
+            # don't include any identfiers in the scan
+            next;
+        }
+        if ($expect_struct == 1) {
+            $expect_struct=0;
             if ($entry eq "\{" ) {
-                $inStruct == 1;
+                $in_struct == 1;
                 next;
             }
-            printf "%s line %d: missing \{ in struct (%s) skipping\n", $doc_file, $line, $struct_name;
+            printf "%s line %d: missing \{ in struct (%s) skipping\n", $current_doc, $line, $struct_name;
             # fall through and see if something else comes up
         }
-        if ($inMultiline == 1) {
+        if ($in_return_value == 1) {
             $test=$entry;
-            if ($entry =~ /^$/) {
+            if ($test =~ /^CKR_/) {
+                $return_values[$return_value_count] = $entry;
+                $return_doc[$return_value_count] = $current_doc;
+                $return_line[$return_value_count] = $line;
+                $return_value_count++;
+                next;
+            }
+            # fall through
+            $in_return_value=0;
+        }
+        if ($in_multiline == 1) {
+            $test=$entry;
+            if ($test =~ /^$/) {
                 if ($verbose == 1) {
                     printf "%s line %d: missing ';' in typedef '%s'\n",
-                           $doc_file, $line, $typedef_names[$typedef_count];
+                           $current_doc, $line, $typedef_names[$typedef_count];
                 }
                 $typedef_names[$typedef_count]=$typedef_names[$typedef_count].";";
-                $inMultiline=0;
+                $in_multiline=0;
                 $typedef_count++;
                 next;
             }
             $typedef_names[$typedef_count]=$typedef_names[$typedef_count]." ".$entry;
             if ($entry =~ ".*;" ) {
-                $inMultiline=0;
+                $in_multiline=0;
                 $typedef_count++;
             }
             next;
         }
-        if ($inStruct == 1) {
+        if ($in_struct == 1) {
             $entry_index=$struct_name."_".$current_row_count;
             $test=$_;
             if ($test =~ /\}\s+($idspec)/) {
                 $typedef_struct_name{$struct_name}=$1;
                 $typedef_struct_count{$struct_name}=$current_row_count;
-                $inStruct=0;
+                $in_struct=0;
                 $current_row_count=0;
                 next;
             }
@@ -314,78 +413,182 @@ if ($doc_file ne "") {
             $current_row_count++;
             next;
         }
-        if ($inTable == 1) {
-            $entry_index=$table_number."_".$current_row_count."_".$current_column_count;
+        if ($in_table == 1) {
+            my $has_line_continue=0;
+            $entry_row=$table_index."_".$current_row_count;
+            $test=$_;
+            if ( $test =~ /\\$/ ) {
+                $has_line_continue=1;
+            }
+            if ($line_continue == 1) {
+                $line_continue = $has_line_continue;
+                next;
+            }
+            $line_continue = $has_line_continue;
+#."_".$current_column_count;
     #printf " handling %d, current_row_count=%d current_column_count=%d entry=%s\n", $table_number, $current_row_count, $current_column_count, $entry;
-            $test=$_;
-            if ($test =~ /^\S/) {
-                # entries with no space at the beginning are continuations of
-                # the last entry, unless we are at the start of a new row
-                if ($tableHeaderNotStarted == 1) {
-                    # continue the table name
-                    $table_name[$table_number]=$table_name[$table_number].$entry;
-                    next;
-                }
-                if ($current_column_count != 0) {
-                    # continue the last entry
-                    $table_entry{$entry_index}=$table_entry{$entry_index}.$entry;
-                    next;
-                }
-    #printf "end table /$_/\n";
-                # we are at the end of the table, this is the prose for the next
-                # section
-                $inTable=0;
-                $table_row_count[$table_number]=$current_row_count;
-                goto MoreParsing;
-            }
-            $test=$_;
-            if ($test =~ /^\sRefer/) {
-                if ($verbose == 1) {
-                    printf "%s line %d: inconsistent footnote reference '%s', whould be '- Refer...' after table %d\n",
-                           $doc_file, $line, $_, $table_number;
-                }
-                # Table ends with footnotes...
-                $inTable=0;
-                $table_row_count[$table_number]=$current_row_count;
-                goto MoreParsing;
-            }
-            $tableHeaderNotStarted=0;
-            $test=$_;
-            # a black line separates rows
-            if ($test =- /^$/) {
-    #printf "end row /$_/\n";
-                if ($current_column_count != 0) {
-                    # there may be multiple blank lines (particularly at the end,
-                    # only record the first
-                    $current_row_count++;
-                    $table_col_count{$table_number."_".$current_row_count}=$current_column_count;
-                    $current_column_count=0;
+            if ($in_table_header == 1) {
+                $test=$_;
+                if ($test =~ /^\+=/) {
+                    $in_table_header=0;
+                    $row_found=0;
                 }
                 next;
             }
-            $table_entry{$entry_index}=$entry;
-    #        printf "index=%s entry=%s\n", $entry_index, $entry;
-            $current_column_count++;
+            $test=$_;
+            if ($test =-/^\|/) {
+                if ($row_found == 1) {
+#Function table #1 generates lots of noise here, so silence this
+#                    if ($verbose == 1) {
+#                        printf "%s line %d: bad table entry, too many rows in row %d table %d\n",
+#                            $current_doc, $line, $current_row_count,$table_number;
+#                    }
+                    next;
+                }
+                @table_columns=split('\|', $_);
+                $current_column_count=0;
+                foreach (@table_columns) {
+                    strip;
+                    $test=$_;
+                    if ($test =~ /^$/) {
+                        next;
+                    }
+                    $table_entry{$entry_row."_".$current_column_count}=$_;
+                    $current_column_count++;
+                }
+                $row_found=1;
+                next;
+            }
+            $test=$_;
+            if ($test =~ /^\+-/) {
+                    $current_row_count++;
+                    $row_found=0;
+                    next;
+            }
+            $test=$_;
+            if ($test =~ /^table: (.*)/) {
+                $in_table=0;
+                $table_name{$table_index}=$1;
+                $table_row_count{$table_index}=$current_row_count;
+                next;
+            }
+            if ($test =~ /^table ($number): (.*)/) {
+                $in_table=0;
+                if ($1 != $table_number) {
+                    printf "%s line %d: explicit table number (%d) does not match table in order (%d).\n",
+                           $current_doc, $line, $1, $table_number ;
+                }
+                $table_name{$table_index}=$2;
+                $table_row_count{$table_index}=$current_row_count;
+                next;
+            }
+            # error no table label
+            printf "%s line %d: missing table label in table %d\n",
+                        $current_doc, $line, $table_number;
+            $table_name{$table_index}="unknown".$table_index;
+            $table_row_count{$table_index}=$current_row_count;
             next;
         }
-MoreParsing:
-        $test=$_;
-        if ($test =~ /^\s*Table\s+(\d+)[,:]\s*(.*)/) {
-            $table_number=$1;
-            $table_name[$table_number]=$2;
-            $table_count[$table_number]=0;
-            $table_index[$table_number]=$table_number;
-            $current_row_count=0;
-            $current_column_count=0;
-            $inTable=1;
-            $tableHeaderNotStarted=1;
-            if ($verbose == 1) {
-                $test=$_;
-                if ($test =~ /^\s*Table\s+(\d+):\s*(.*)/) {
-                    printf "%s line %d: inconsistent Table Title(%s) in table %d. Should have a comma rather than a colon\n",
-                           $doc_file, $line, $entry, $table_number;
-                }
+        if ($in_table_2 == 1) {
+            my $has_line_continue=0;
+            $entry_row=$table_index."_".$current_row_count;
+            $test=$_;
+            if ( $test =~ /\\$/ ) {
+                $has_line_continue=1;
             }
+            if ($line_continue == 1) {
+                $line_continue = $has_line_continue;
+                next;
+            }
+            $line_continue = $has_line_continue;
+            if ($in_table_header == 1) {
+                $test=$_;
+                if ($test =~ /^\|-/) {
+                    $in_table_header=0;
+                }
+                next;
+            }
+            $test=$_;
+            if ($test =-/^\|/) {
+                @table_columns=split('\|', $_);
+                $current_column_count=0;
+                foreach (@table_columns) {
+                    strip;
+                    $test=$_;
+                    if ($test =~ /^$/) {
+                        next;
+                    }
+                    $table_entry{$entry_row."_".$current_column_count}=$_;
+                    $current_column_count++;
+                }
+                $current_row_count++;
+                next;
+            }
+            $test=$_;
+            if ($test =~ /^table: (.*)/) {
+                $in_table_2=0;
+                $table_name{$table_index}=$1;
+                $table_row_count{$table_index}=$current_row_count;
+                next;
+            }
+            if ($test =~ /^table ($number): (.*)/) {
+                $in_table_2=0;
+                if ($1 != $table_number) {
+                    printf "%s line %d: explicit table number (%d) does not match table in order (%d).\n",
+                           $current_doc, $line, $1, $table_number ;
+                }
+                $table_name{$table_index}=$2;
+                $table_row_count{$table_index}=$current_row_count;
+                next;
+            }
+            $in_table_2=0;
+            # error no table label
+            printf "%s line %d: missing table label in table %d\n",
+                           $current_doc, $line, $table_number;
+            $table_name{$table_index}="unknown".$table_index;
+            $table_row_count{$table_index}=$current_row_count;
+            next;
+        }
+        $test=$entry;
+        if ($test =~ /^Return [Vv]alues: (.*)$/) {
+            $return_values[$return_value_count] = $1;
+            $return_doc[$return_value_count] = $current_doc;
+            $return_line[$return_value_count] = $line;
+            $return_value_count++;
+            $in_return_value=1;
+            next;
+        }
+        $test=$_;
+        if ($test =~ /^\+-/) {
+            # table name gets assigned at the end where the table label is.
+            #$table_name{$table_index}=$2;
+            $table_number=$table_number + 1;
+            $table_total_count=$table_total_count + 1;
+            $table_index=$doc_dir."_".$table_number;
+            $table_doc{$table_index}=$current_doc;
+            $table_row_count{$table_index}=0;
+            $table_indices[$table_total_count]=$table_index;
+            $current_row_count=0;
+            $row_found=0;
+            $current_column_count=0;
+            $in_table=1;
+            $in_table_header=1;
+            next;
+        }
+        if ($test =~ /^\|/) {
+            # table name gets assigned at the end where the table label is.
+            #$table_name{$table_index}=$2;
+            $table_number=$table_number + 1;
+            $table_total_count=$table_total_count + 1;
+            $table_index=$doc_dir."_".$table_number;
+            $table_doc{$table_index}=$current_doc;
+            $table_row_count{$table_index}=0;
+            $table_indices[$table_total_count]=$table_index;
+            $current_row_count=0;
+            $row_found=0;
+            $current_column_count=0;
+            $in_table_2=1;
+            $in_table_header=1;
             next;
         }
         $test=$_;
@@ -394,7 +597,7 @@ MoreParsing:
     #print "in typedefs with \{ entry=$entry, name=$1\n"
             $struct_name=$1;
             $current_row_count=0;
-            $inStruct=1;
+            $in_struct=1;
             next;
         }
         $test=$_;
@@ -402,7 +605,7 @@ MoreParsing:
             # Same as above except the  brackets start on the next line, go find it
             $struct_name=$1;
             $current_row_count=0;
-            $expectStruct=1;
+            $expect_struct=1;
             next;
         }
         if ($test =~ /typedef CK_CALLBACK_FUNCTION\(CK_RV, myCallbackType\)/) {
@@ -416,16 +619,26 @@ MoreParsing:
         if ($test =~ /typedef CK_CALLBACK_FUNCTION\(($idspec), ($idspec)\)\(/) {
             # handle callbacks multiline
             $typedef_names[$typedef_count]=$entry;
-            $inMultiline=1;
+            $in_multiline=1;
             next;
         }
         $test=$_;
-        if ($test =~/^· (CKR_$idspec):/) {
+        if (($short_doc eq "function_return_values.md") && ($test =~/^\* (CKR_$idspec):/)) {
             $name=$1;
             $doc_found{$name}=0;
             $doc_present{$name}=1;
             $doc_number{$name}=0;
             next;
+        }
+        # handle naked return codes to make sure they are defined in their proper places.
+        $test=$_;
+        if ($test =~ /(CKR_$idspec)/) {
+            $name=$1;
+            $naked_return_values[$naked_return_count]=$1;
+            $naked_return_doc[$naked_return_count]=$current_doc;
+            $naked_return_line[$naked_return_count]=$line;
+            $naked_return_count++;
+            # continue processing
         }
         $test=$_;
         if ($test =~ /typedef .*;/) {
@@ -438,19 +651,30 @@ MoreParsing:
         if ($test =~ /typedef .*/) {
             # Same as above, but the semi colon was just missing
             $typedef_names[$typedef_count]=$entry;
-            $inMultiline=1;
+            $in_multiline=1;
             next;
         }
         $test=$_;
          # the following defines are just in the text, not in tables,
          # just scower them out.
-        if ($test =~ /(CK[CFGHNOSU]_$idspec)/) {
+         # first process the bold versions, so we don't put spurious
+         # version of this id with an extra '_'
+        if ($test =~ /_(CK[CDFGHNOSTUV]_$idspec)_/) {
             $name=$1;
             $doc_found{$name}=0;
             $doc_present{$name}=1;
             $doc_number{$name}=0;
             next;
         }
+        # now process the rest.
+        if ($test =~ /(CK[CDFGHNOSTUV]_$idspec)/) {
+            $name=$1;
+            $doc_found{$name}=0;
+            $doc_present{$name}=1;
+            $doc_number{$name}=0;
+            next;
+        }
+        $test=$_;
         if ($test =~/^CK_KEY_TYPE/) {
              # for keytypes, skip C code examples, make sure we have the
              # definition in the text
@@ -459,17 +683,35 @@ MoreParsing:
         $test=$_;
         if ($test =~ /(CKK_$idspec)/) {
             $name=$1;
+            if (exists $doc_present{$name}) {
+                next;
+            }
             $doc_found{$name}=0;
             $doc_present{$name}=1;
             $doc_number{$name}=0;
             next;
         }
         $test=$_;
+        if ($test =~/^PARAM_SET_TYPE/) {
+             # for keytypes, skip C code examples, make sure we have the
+             # definition in the text
+            next;
+        }
+        $test=$_;
+        if ($test =~ /(CKP_$idspec)/) {
+            $name=$1;
+            $doc_found{$name}=0;
+            $doc_present{$name}=1;
+            $doc_number{$name}=0;
+            next;
+        }
+        $test=$_;
+        $test=$_;
         if ($test =~ /(CK_CERTIFICATE_CATEGORY_$idspec)/) {
             $name=$1;
-            if (($verbose == 1) && ($doc_present{$name} == 0)) {
+            if (($verbose == 1) && (!exists $doc_present{$name})) {
                     printf "%s line %d: %s in unlabelled table.\n",
-                           $doc_file, $line, $name;
+                           $current_doc, $line, $name;
             }
             $doc_found{$name}=0;
             $doc_present{$name}=1;
@@ -479,10 +721,17 @@ MoreParsing:
         $test=$_;
         if ($test =~ /(CK_SECURITY_DOMAIN_$idspec)/) {
             $name=$1;
-            if (($verbose == 1) && ($doc_present{$name} == 0)) {
+            if (($verbose == 1) && (!exists $doc_present{$name})) {
                     printf "%s line %d: %s in unlabelled table.\n",
-                           $doc_file, $line, $name;
+                           $current_doc, $line, $name;
             }
+            $doc_found{$name}=0;
+            $doc_present{$name}=1;
+            $doc_number{$name}=0;
+            next;
+        }
+        $name=has_identifier($_,@special_identifiers);
+        if ($name) {
             $doc_found{$name}=0;
             $doc_present{$name}=1;
             $doc_number{$name}=0;
@@ -490,6 +739,8 @@ MoreParsing:
         }
     }
     close($doc);
+   }
+  }
 }
 
 # read the same stuff out of the header file
@@ -497,17 +748,14 @@ if ($header_file ne "") {
     process_header($header_file, 0);
 }
 
-# read the same stuff out of the function header file
-#if ($function_header_file ne "") {
-#    process_header($function_header_file, 1);
-#}
-
 # extract the defines from the tables
-foreach (@table_index) {
+foreach (@table_indices) {
     $index=$_;
-    for my $i (1..($table_row_count[$index]-1)) {
+    $is_OTP=0;
+    for my $i (0..($table_row_count{$index}-1)) {
         $entry1=$index."_".$i."_"."0";
         $entry2=$index."_".$i."_"."1";
+        $entry3=$index."_".$i."_"."2";
         $name=get_name($table_entry{$entry1});
         if ($name ne "" ) {
             $doc_found{$name}=0;
@@ -518,21 +766,118 @@ foreach (@table_index) {
                 $doc_table_number{$name}=$index;
             } else {
                 if ($doc_number{$name} != $number) {
-                    printf("%s: identifier %s has inconsistant values 0x%08xUL (Table %d) and 0x%08xUL (Table %d)\n",
-                            $doc_file, $name, $header_number{$name},
+                    printf("%s: identifier %s has inconsistant values 0x%08xUL (Table %s) and 0x%08xUL (Table %s)\n",
+                            $table_doc{$index}, $name, $header_number{$name},
                             $doc_table_number{$name}, $number, $index);
                 }
+            }
+            $test=$name;
+            if ($test =~ /CKA_OTP_/) {
+                $is_OTP=1;
             }
             next;
         }
         $name=get_name($table_entry{$entry2});
         if ($name ne "" ) {
-            if ($doc_present{$name} != 0) {
+            if (!exists $doc_present{$name}) {
                 $doc_number{$name}= 0;
             }
             $doc_found{$name}=0;
             $doc_present{$name}=1;
+        } else {
+            # handle the case where ther is more than one
+            # basically CKK_DES3 will never be found without this.
+            my $names=$table_entry{$entry2};
+            while ($names =~ /(CK[A-Z]_$idspec)(.*)$/) {
+                $name=$1;
+                $names=$2;
+                if (!exists $doc_present{$name}) {
+                    $doc_number{$name}= 0;
+                }
+                $doc_found{$name}=0;
+                $doc_present{$name}=1;
+            }
         }
+        if ($is_OTP) {
+            $test=$table_entry{$entry3};
+            if ($test =~ /(CK_OTP_$idspec) =/) {
+                $name=$1;
+                if (!exists $doc_present{$name}) {
+                    $doc_number{$name}= 0;
+                }
+                $doc_found{$name}=0;
+                $doc_present{$name}=1;
+            }
+        }
+    }
+}
+
+
+
+# process the return values
+# return values should be defined in in function_return_values.md
+# find those cases where we have a return value defined in
+# a function return list but not in function_return_values.md
+# We output an error and then add the table to the list of
+# expected defines to make sure that they are in the header.
+my %missing_return_doc= ();
+for my $i (0..($return_value_count-1)) {
+    foreach (fetch_return($return_values[$i])) {
+        $value=$_;
+        if (!exists $doc_present{$value}) {
+            my $doc_spec= "$return_doc[$i]:$return_line[$i]";
+            if ($missing_return_doc{$value}) {
+                $missing_return_doc{$value}=$missing_return_doc{$value}.",$doc_spec";
+            } else {
+                $missing_return_doc{$value}=$doc_spec;
+            }
+        }
+    }
+}
+# print and load the up at the end... this allows us
+# to output all the places that the entry could fall into
+if (%missing_return_doc) {
+    print "The following return codes were used in function retun blocks, but\n";
+    print " not define in 'function_return_values.md' return code section:\n";
+}
+foreach (sort keys %missing_return_doc) {
+    $name=$_;
+    print "    $name define in $missing_return_doc{$name}\n";
+    # add it to the defines expected in the headers.
+    $doc_number{$name}= 0;
+    $doc_found{$name}=0;
+    $doc_present{$name}=1;
+}
+
+# now preload CKR_VENDOR_DEFINED. It should not appear in the function return
+# lists, but it's meantioned legitmately in general_data_type.md, we don't
+# want it to show up in these list, but we do want it in the header file
+$name="CKR_VENDOR_DEFINED";
+$doc_number{$name}=0;
+$doc_found{$name}=0;
+$doc_present{$name}=1;
+
+# now handle naked return codes we find in the text proper
+my $need_print_header=1;
+for my $i (0..($naked_return_count-1)) {
+    $value=$naked_return_values[$i];
+    if (!exists $doc_present{$value}) {
+        if ($need_print_header) {
+            print "The following return codes were used in the spec but defined in neither\n";
+            print " function return blocks nor in 'function_return_values.md':\n";
+            $need_print_header=0;
+        }
+        print "    $value defined in $naked_return_doc[$i] line $naked_return_line[$i]\n";
+    }
+}
+
+# we do the loop again so we can catch muliple occurances of the naked return value
+for my $i (0..($naked_return_count-1)) {
+    $value=$naked_return_values[$i];
+    if (!exists $doc_present{$value}) {
+        $doc_number{$value}= 0;
+        $doc_found{$value}=0;
+        $doc_present{$value}=1;
     }
 }
 
@@ -596,11 +941,12 @@ if ($print_diff_struct) {
 sub process_header
 {
     my ($l_header_file, $l_verbose)=@_;
+    my %is_specific = map { $_ => 1 } @header_specific;
     print "Processing header $l_header_file...\n";
 
     open(my $header, "<", $l_header_file) or die "Can't open $l_header_file: $!";
     while (<$header>) {
-        chomp;   # clear out new line 
+        chomp;   # clear out new line
         $entry=$_;
         # remove comments first
         $entry=~s/\/\*.*\*\///g;
@@ -608,36 +954,55 @@ sub process_header
         $entry=~s/^\s+|\s+$//;
         # normalize spacing to just one space to aid comparisons
         $entry=~s/\s+/ /g;
-        next if /^$/; # skip blank line 
-        if ($l_verbose != 0) {
-            print "processing \$entry=<$entry> \$inMultiline=$inMultiLine \$expectStruct=$expectStruct \$inStruct=$inStruct\n";
+        $is_skipping=$next_deprecated || $next_historical || $next_profile;
+        $test=$_;
+        if ( $test =~ /^[\s\/]\* Deprecated/ ) {
+            $next_deprecated=1;
+        } else {
+            $next_deprecated=0;
         }
-        if ($inMultiline == 1) {
+        $test=$_;
+        if ($has_historical == 0 && $test =~ /^[\s\/]\* Historical/ ) {
+            $next_historical=1;
+        } else {
+            $next_historical=0;
+        }
+        $test=$_;
+        if ($has_profile == 0 && $test =~ /^[\s\/]\* Profile Only/ ) {
+            $next_profile=1;
+        } else {
+            $next_profile=0;
+        }
+        next if /^$/; # skip blank line
+        if ($l_verbose != 0) {
+            print "processing \$entry=<$entry> \$in_multiline=$in_multiline \$expect_struct=$expect_struct \$in_struct=$in_struct\n";
+        }
+        if ($in_multiline == 1) {
             $entry=~s/\\$//;
             $entry=~s/^\s+|\s+$//;
             $header_typedef_names[$header_typedef_count]=$header_typedef_names[$header_typedef_count]." ".$entry;
             if ($entry =~ ".*;" ) {
-                $inMultiline=0;
+                $in_multiline=0;
                 $header_typedef_count++;
             }
             next;
         }
-        if ($expectStruct == 1) {
-            $expectStruct=0;
+        if ($expect_struct == 1) {
+            $expect_struct=0;
             if ($entry eq "\{" ) {
-                $inStruct == 1;
+                $in_struct == 1;
                 next;
             }
             printf "%s: missing \{ in struct (%s) skipping\n", $l_header_file, $struct_name;
             # fall through and see if something else comes up
         }
-        if ($inStruct == 1) {
+        if ($in_struct == 1) {
             $entry_index=$struct_name."_".$current_row_count;
             $test=$_;
             if ($test =~ /\}\s+($idspec)/) {
                 $header_typedef_struct_name{$struct_name}=$1;
                 $header_typedef_struct_count{$struct_name}=$current_row_count;
-                $inStruct=0;
+                $in_struct=0;
                 $current_row_count=0;
                 next;
             }
@@ -647,6 +1012,11 @@ sub process_header
             $current_row_count++;
             next;
         }
+        # if we have a deprecated, historical or profile comment, just skip parsing the next line
+        if ($is_skipping) {
+            next;
+        }
+
         @db = split(" ");
         if ($db[0] eq "#define") { # handle #defines
             if ($l_verbose != 0) { print "    is a define\n"; }
@@ -655,18 +1025,22 @@ sub process_header
             $comment=$db[4];
             if ($comment eq "Deprecated") {
                 if ($l_verbose != 0) { print "    Deprecated\n"; }
-                next; # skip deprecated defines 
+                next; # skip deprecated defines
             }
-            if ($comment eq "Historical") {
+            if ($has_historical == 0 && $comment eq "Historical") {
                 if ($l_verbose != 0) { print "    Historical ID\n"; }
                 next; # skip historical defines, they are documented in
                       # the historical algorithms spec.
-            } 
-            if ($comment eq "Profile") {
+            }
+            if ($has_profile == 0 && $comment eq "Profile") {
                 if ($l_verbose != 0) { print "    Profile ID\n"; }
                 next; # skip profile ID, they are documented
                       # profile spec.
-            } 
+            }
+            if ( exists $is_specific{$name} ) {
+                if ($l_verbose !=0)  { print "    Header Specific\n"; }
+                next; # skip header specific defines
+            }
             $test=$number;
             if ($test =~ /^CK$idspec/) {
                 if ($l_verbose != 0) { print "    alias\n"; }
@@ -676,7 +1050,7 @@ sub process_header
             if (($number == 0) and (substr($db[2],1,19) eq "CKF_ARRAY_ATTRIBUTE")) {
                 $number=hex(substr($db[2],21));
             }
-            # handle a substitution 
+            # handle a substitution
             if (($number == 0xc) and (substr($db[2],0,2) eq "CK")) {
                 if ($l_verbose != 0) { print "    substitution\n"; }
                 $number = $header_number{$db[2]};
@@ -685,7 +1059,7 @@ sub process_header
             $header_found{$name} = 0;
             $header_present{$name} = 1;
             $header_line{$name} = $_;
-            # give VENDER_DEFINED a pass 
+            # give VENDER_DEFINED a pass
             if (($number == 0x80000000) && (substr($name,4) eq "VENDOR_DEFINED")) {
                 if ($l_verbose != 0) { print "    vendor_defined\n"; }
                 $header_found{$name} = 1;
@@ -704,22 +1078,22 @@ sub process_header
                         $entry =~ s/\\$//;
                         $entry=~s/^\s+|\s+$//;
                         $header_typedef_names[$header_typedef_count]=$entry;
-                        $inMultiline=1;
+                        $in_multiline=1;
                         next;
                     }
                     $header_typedef_count++;
                     next;
                 }
                 $name=$db[2];
-                $inStruct=1;
-                $expectStruct=0;
+                $in_struct=1;
+                $expect_struct=0;
                 if ($name =~ /($idspec)\{/ ) {
                     $name=$1
                 } else {
                     if ($db[3] ne "\{") {
                          #print "no '\{' on line entry=$entry, name=$name, db[2]=$db[2] db[3]=$db[3]\n";
-                        $expectStruct=1;
-                        $inStruct=0;
+                        $expect_struct=1;
+                        $in_struct=0;
                     }
                 }
                 $struct_name=$name;
@@ -732,7 +1106,7 @@ sub process_header
                 $entry =~ s/\\$//;
                 $entry=~s/^\s+|\s+$//;
                 $header_typedef_names[$header_typedef_count]=$entry;
-                $inMultiline=1;
+                $in_multiline=1;
                 next;
             }
             $header_typedef_names[$header_typedef_count]=$entry;
@@ -743,61 +1117,58 @@ sub process_header
     close ($header);
 }
 
+sub fetch_return
+{
+    my ($line)=@_;
+    my $test;
+    my @returns = ();
+
+    $test=$line;
+    while ($test =~ /(CKR_$idspec)(.*)$/) {
+        $test=$2;
+        push(@returns,$1);
+    }
+    return @returns;
+}
+
 sub get_name
 {
     my ($candidate)=@_;
     my $test;
-    # print " getname($candidate)=";
+    #print " getname('$candidate')=";
     # strip leading and trailing spaces
-    $candidate=~s/^\s+|\s+$//;
+    $candidate=~s/^\s+|\s+$//g;
     #strip the obvious notes
-    $test=$candidate;
     $candidate=~s/\,\d\d?//g;
-    # carefully strip the last note value
-    # from the attributes
-    $test=$candidate;
-    if ($test =~ /^CKA_\w+$/) {
-        $test=$candidate;
-        # attributes with legitimate ending digits
-        if ($test =~ /(^CKA_PRIME_[12])/) {
-             #print "$1 (CKA_PRIME)\n";
-            return $1;
-        }
-        if ($test =~ /(^CKA_EXPONENT_[12])/) {
-             #print "$1 (CKA_EXPONENT)\n";
-            return $1;
-        }
-        # non of the rest should have trailing digits
-        $candidate=~s/\d*$//;
-        return $candidate
-    }
+    $candidate=~s/ \^\d+\^$//g;
+    $candidate=~s/\^\d+\^$//g;
     $test=$candidate;
     if ($test =~ /^CK[A-Z]_\w+$/) {
-          #print "$candidate (CK[A-Z]_*)\n";
+        #print "$candidate (CK[A-Z]_*)\n";
         return $candidate;
     }
     $test=$candidate;
     # handle the defines that didn't follow the CKx_ format
     if ($test =~ /^CK_OTP_\w+$/) {
        #if we need to reject CK_OTP_PARAMS*, doit here
-          #print "$candidate (CK_OTP_*)\n";
+       #print "$candidate (CK_OTP_*)\n";
        return $candidate;
     }
     if ($test =~ /^CK_SP800_108_\w+$/) {
-         #print "$candidate (CK_SP800_108_*)\n";
+       #print "$candidate (CK_SP800_108_*)\n";
        return $candidate;
     }
     if ($test =~ /^CK_CERTIFICATE_CATEGORY_\w+$/) {
-         #print "$candidate (CK_CERTIFICATE_CATEGORY_*)\n";
+       #print "$candidate (CK_CERTIFICATE_CATEGORY_*)\n";
        return $candidate;
     }
     if ($test =~ /^CK_SECURITY_DOMAIN_\w+$/) {
-         #print "$candidate (CK_SECURITY_DOMAIN_*)\n";
+       #print "$candidate (CK_SECURITY_DOMAIN_*)\n";
        return $candidate;
     }
     # do we need CK_TRUE, CK_FALSE, CK_UNAVAILABLE_INFORMATION,
     # or CK_EFFECTIVELY_INFINITE?
-      #print "\"\" (candidate=$candidate)\n";
+    #print "\"\" (candidate='$candidate')\n";
     return "";
 }
 
@@ -805,6 +1176,8 @@ sub get_value
 {
     my ($value)=@_;
 
+    # strip leading and trailing spaces
+    $value=~s/^\s+|\s+$//g;
     # make sure it's a hex value
     $test=$value;
     if ( $test =~ /^0x[A-Fa-f0-9]*/ ) {
@@ -819,6 +1192,23 @@ sub get_value
         return $test;
     }
     return 0;
+}
+
+sub has_identifier
+{
+    my ($value, @array)=@_;
+
+    if ($value eq "") {
+        return "";
+    }
+
+    foreach (@array) {
+        my $test=$value;
+        if ($test =~ /$_/ ) {
+            return $_;
+        }
+    }
+    return "";
 }
 
 sub print_typedefs
@@ -844,19 +1234,14 @@ sub print_structs
 
 sub print_table
 {
-    foreach (@table_index) {
+    foreach (@table_indices) {
         $index=$_;
-        if ($index == 0) {
+        if ($index eq "") {
             next;
         }
-        printf " Table %03d, %s\n", $index, $table_name[$index];
-        $entry1=$index."_"."0"."_"."0";
-        $entry2=$index."_"."0"."_"."1";
-        # printf("index1=$entry1 index2=$entry2\n");
+        printf " Table %s, %s\n", $index, $table_name{$index};
         printf " -----------------------------------------------------------------------------------\n";
-        printf " |%-40s|%-40s|\n", $table_entry{$entry1}, $table_entry{$entry2};
-        printf " -----------------------------------------------------------------------------------\n";
-        for my $i (1..($table_row_count[$index]-1)) {
+        for my $i (0..($table_row_count{$index}-1)) {
            $entry1=$index."_".$i."_"."0";
            $entry2=$index."_".$i."_"."1";
            #printf("index1=$entry1 index2=$entry2\n");
@@ -932,16 +1317,16 @@ sub print_diff_defines
     }
     foreach (sort keys %header_number)  {
         $name=$_;
-        if ($doc_present{$name} == 0) {
-            if ($verbose2 == 1) {
-                printf "#define %-40s 0x%08xUL missing from doc %s (may not be and error)\n",
+        if (!exists $doc_present{$name}) {
+            if ($silence_doc_errors == 0) {
+                printf "#define %-40s 0x%08xUL missing from doc '%s' (may not be and error)\n",
                        $name, $header_number{$name}, $doc_file;
             } else {
                 $missing_in_doc++;
             }
         }
     }
-    if (($verbose2 == 0) && ($missing_in_doc != 0)) {
+    if (($silence_doc_errors == 1) && ($missing_in_doc != 0)) {
         printf"%d defines in header (%s) and not in doc (%s)\n",
                 $missing_in_doc, $header_file, $doc_file;
     }
@@ -983,14 +1368,14 @@ sub print_diff_struct
     foreach (sort keys %header_typedef_struct_name)  {
         $index=$_;
         if ( $typedef_struct_name{$index} eq "" ) {
-            if ($verbose2 == 1) {
+            if ($silence_doc_errors == 0) {
                 printf "struct '%s' missing in doc %s\n", $index, $doc_file;
             } else {
                 $missing_structs++;
             }
         }
     }
-    if (($verbose2 == 0) and ($missing_structs !=0)) {
+    if (($silence_doc_errors == 1) and ($missing_structs !=0)) {
         printf"%d structs in header (%s) and not in doc (%s)\n",
                 $missing_structs, $header_file, $doc_file;
     }
@@ -1032,7 +1417,7 @@ sub print_diff_typedefs
             if (($test =~ /typedef.*\sCK_PTR\s.*_PTR;$/) and $verbose2 == 0 ) {
                 $ckptr_count++;
             } else {
-                printf "typedef (%s) missing from doc %s\n", $name, $doc_file;
+                printf "typedef (%s) missing from doc '%s'\n", $name, $doc_file;
             }
         }
     }
@@ -1043,27 +1428,35 @@ sub print_diff_typedefs
 
 sub usage
 {
-    printf "Usage: %s [commands...] [doc_file] [header_file]\n", Command;
-    print " parse a doc text file and/or a header file and output according\n";
-    print " to the command:\n";
-    print "    verbose:  output inconsistancies in the doc_file\n";
+    printf "Usage: %s [commands...] [header_file] [doc_directories ... ]\n", Command;
+    print " parse one or more markdown documents and/or a header file and output\n";
+    print " according to the command:\n";
+    print "    base={base_dir}:  location of the root of the working tree, default is ../\n";
+    print "    verbose:  output inconsistancies in the document\n";
     print "    verbose2:  output objects in the header_file that are not in the doc_file\n";
-    print "    table:  the first two columns of every table in the doc_file\n";
-    print "    defines:  all the defines in both the doc_file and header_file\n";
-    print "    typedefs:  all the typedefs in both the doc_file and header_file\n";
-    print "    structs:  all the structs in both the doc_file and header_file\n";
-    print "    doc_defines:  all the defines in the doc_file\n";
-    print "    doc_typedefs:  all the typedefs in the doc_file\n";
-    print "    doc_structs:  all the structs in the doc_file\n";
-    print "    doc_all:  all the parsed values in the doc_file\n";
+    print "    no_doc_errors:  only print a summary of missing document values\n";
+    print "    table:  the first two columns of every table in the document(s)\n";
+    print "    defines:  all the defines in both the document(s)and header_file\n";
+    print "    typedefs: all the typedefs in both the document(s) and header_file\n";
+    print "    structs:  all the structs in both the documents(s) and header_file\n";
+    print "    doc_defines:     all the defines in the document(s)\n";
+    print "    doc_typedefs:    all the typedefs in the document(s)\n";
+    print "    doc_structs:     all the structs in the document(s)\n";
+    print "    doc_all:         all the parsed values in the document(s)\n";
     print "    header_defines:  all the defines in the header_file\n";
-    print "    header_typedefs:  all the typedefs in the header_file\n";
+    print "    header_typedefs: all the typedefs in the header_file\n";
     print "    header_structs:  all the structs in the header_file\n";
-    print "    header_all:  all the parsed values in the doc_file\n";
-    print "    diff_defines:  the differences betweeen the defines in the doc_file and the header_file\n";
-    print "    diff_typedefs: the differences between the typedefs in doc_file and header_file\n";
-    print "    diff_structs:  the differences between the structs in doc_file andthe header_file\n";
+    print "    header_all:      all the parsed values in the document(s)\n";
+    print "    diff_defines:  the differences betweeen the defines in the document(s) and the header_file\n";
+    print "    diff_typedefs: the differences between the typedefs in document(s) and header_file\n";
+    print "    diff_structs:  the differences between the structs in document(s) and the header_file\n";
     print "    diff_all:  all the diffs\n";
-    print "if both files are required, the doc_file must be first, if no\n";
-    print "commands are supplied, then diff_all is assumed\n";
+    print "1. documents are specified by the directory. files.txt or \n";
+    print "   spec_files.txt are read to find the individual files of the doc.\n";
+    print "2. if more than one document directory is specified all directories\n";
+    print "   are read and treated as one combined document. Adding profile and\n";
+    print "   historical directories will turn on scanning of those defines\n";
+    print "   in the header.\n";
+    print "3. if documents and the header is required, the header_file must be first.\n";
+    print "4. if no commands are supplied, then diff_all is assumed.\n";
 }


### PR DESCRIPTION
parse doc now takes a list of directors for the document rather than a single file. It parses markdown rather then whatever funky ascii output was being used by OASIS.

I also added scanning for naked CKR_ values in the document itself and warning if we find CKR_ values that weren't defined in our list of return codes.

Since we have the historical and profiles documents available, the scanner will accept header defines that are expected to be in those docuemnts. *NOTE* you should always scan these with the main spec or you will get lots of spurious 'missing define from doc' in the output.